### PR TITLE
blocktree adr

### DIFF
--- a/docs/adr/004-abstract-blocktree.md
+++ b/docs/adr/004-abstract-blocktree.md
@@ -1,0 +1,17 @@
+---
+slug: 1
+title: |
+  1. Abstract blocktree
+authors: []
+tags: [Draft]
+---
+
+## Status
+
+Draft
+
+## Context
+
+## Decision
+
+## Consequences

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,3 +2,4 @@
 
 1. [Use ADRs](001-record-architectural-decisions.md)
 2. [Agda is ground truth](002-generate-interfaces-from-agda.md)
+4. [Blocktree is abstract](004-abstract-blocktree.md)


### PR DESCRIPTION
This PR adds an ADR explaining why the formal specification does not provide an implementation of a block-tree but rather only a type for it