### PR TITLE
Work around with-abstraction issue in NodeModel proof obligations

### DIFF
--- a/src/Peras/Conformance/Model.agda
+++ b/src/Peras/Conformance/Model.agda
@@ -484,6 +484,10 @@ headBlockHash (b ∷ _) = Hashable.hash hashBlock b
 
 {-# COMPILE AGDA2HS headBlockHash #-}
 
+opaque
+  makeCheckedVote : (v : Vote) → checkSignedVote v ≡ True → CheckedVote
+  makeCheckedVote v prf = v P., prf
+
 transition : NodeModel → EnvAction → Maybe (List Vote × NodeModel)
 transition s Tick =
   let s' = record s { clock = nextSlot (clock s) } in
@@ -513,7 +517,7 @@ transition s (NewVote v) = do
   guard (votingBlockHash s == blockHash v)
   Just ([] ,
     let s' = addVote' s v
-    in record s' { allVotesChecked = ( v P., prf ) ∷ (allVotesChecked s')})
+    in record s' { allVotesChecked = makeCheckedVote v prf ∷ (allVotesChecked s')})
 transition s (BadVote v) = do
   guard (hasVoted (voterId v) (votingRound v) s)
   Just ([] , s)

--- a/src/Peras/Conformance/Soundness.agda
+++ b/src/Peras/Conformance/Soundness.agda
@@ -354,10 +354,11 @@ module _ ⦃ _ : Hashable (List Tx) ⦄
          | div (getSlotNumber (State.clock s₀)) (Params.U params)
              == getRoundNumber (votingRound vote) in isVotingRound
          | checkSignedVote vote in checkedSig
+         | makeCheckedVote vote
          | checkVoteFromOther vote in checkedOther
          | isYes (checkVotingRules (modelState s₀)) in checkedVRs
          | votingBlockHash (modelState s₀) == blockHash vote in isValidBlockHash
-    newVote-soundness {vs} {ms₁} s₀ vote inv refl | True | True | True | True | True | True =
+    newVote-soundness {vs} {ms₁} s₀ vote inv refl | True | True | True | makeChecked | True | True | True =
       record
         { s₁          = s₁
         ; invariant₀  = inv


### PR DESCRIPTION
The problem we're having is that if you abstract over `checkSignedVote v`, the type of `prf` changes from `checkSignedVote v ≡ True` to `w ≡ True` making `v , prf` not a well-typed `CheckedVote`. The trick is to break out the `v , prf` into a new opaque function `makeCheckedVote` and then abstract over `makeCheckedVote v` at the same time as we abstract over `checkSignedVote v`. We then end up with
```agda
prf : w ≡ True
makeChecked : w ≡ True → CheckedVote
transition s (Vote v) = do
  ...
  prf ← guard w
  ... record s' { allVotesChecked = makeChecked prf :: allVotesChecked s' }
```
which is well typed. You might need to prove some properties about `makeCheckedVote` if you actually need the `prf`.
  
